### PR TITLE
Update README.md with ludus ansible role add

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ An Ansible role that installs and spins up a Cobalt Strike Teamserver on a Debia
 
 ## Requirements
 - You need to supply a valid Cobalt Strike license for this to be successful.
+- Add the Ludus Ansible Galaxy Role.
+  ```ludus ansible role add 0xRedpoll.ludus_cobaltstrike_teamserver```
 
 ## Role Variables
 


### PR DESCRIPTION
To make this more easy for others to add the role via the command: ```ludus ansible role add 0xRedpoll.ludus_cobaltstrike_teamserver```